### PR TITLE
feat!: don't chunk the documents

### DIFF
--- a/cdk/cdk_stack.py
+++ b/cdk/cdk_stack.py
@@ -130,22 +130,22 @@ class CdkStack(Stack):
             name=f"source{construct_id}",
 
             # # the properties below are optional
-            # data_deletion_policy="dataDeletionPolicy",
+            data_deletion_policy="DELETE",
             # description="description",
             # server_side_encryption_configuration=bedrock.CfnDataSource.ServerSideEncryptionConfigurationProperty(
             #     kms_key_arn="kmsKeyArn"
             # ),
-            # vector_ingestion_configuration=bedrock.CfnDataSource.VectorIngestionConfigurationProperty(
-            #     chunking_configuration=bedrock.CfnDataSource.ChunkingConfigurationProperty(
-            #         chunking_strategy="chunkingStrategy",
+            vector_ingestion_configuration=bedrock.CfnDataSource.VectorIngestionConfigurationProperty(
+                chunking_configuration=bedrock.CfnDataSource.ChunkingConfigurationProperty(
+                    chunking_strategy="NONE",
 
-            #         # the properties below are optional
-            #         fixed_size_chunking_configuration=bedrock.CfnDataSource.FixedSizeChunkingConfigurationProperty(
-            #             max_tokens=123,
-            #             overlap_percentage=123
-            #         )
-            #     )
-            # )
+                    # # the properties below are optional
+                    # fixed_size_chunking_configuration=bedrock.CfnDataSource.FixedSizeChunkingConfigurationProperty(
+                    #     max_tokens=123,
+                    #     overlap_percentage=123
+                    # )
+                )
+            )
         )
 
         CfnOutput(self, "Knowledge Base ID: ", value=cfn_knowledge_base.attr_knowledge_base_id)


### PR DESCRIPTION
We should not further split the documents since they are already small enough. Having split documents will make information scattered and difficult to retrieve properly.